### PR TITLE
add-queue-of-experiment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .vscode
 .idea
 experiments
+results
 venv
 
 *.code-workspace

--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,4 @@ venv
 
 *.csv
 .history/
-/experiments/SALP/
+

--- a/experiment_executor.py
+++ b/experiment_executor.py
@@ -75,7 +75,7 @@ def experiment_one(num_of_samples, period, num_of_nodes, algorithms, shape, scal
 
     min_parallel_requests = round(processing_time / (periods_in_vector * num_of_nodes * 0.9))
     max_parallel_requests = round(processing_time / (periods_in_vector * num_of_nodes * 0.1))
-
+    
     delays_df = pd.DataFrame(columns=['algorithm', 'nodes', 'cload_load_lvl', 'sum_of_delay', 'delay_percentage'])
     imbalance_df = pd.DataFrame(columns=['algorithm', 'nodes', 'cload_load_lvl', 'sum_of_imbalance', 'imbalance_percentage'])
 
@@ -220,6 +220,13 @@ def calculate_imbalance_level(algorithm, nodes, load_vectors, nodes_detail_df, s
 
 def generate_imbalance_plots(imbalance_lvl, param_x, xLabel, plotTitle):
     plt.clf()
+    if(param_x == "cloud_load"):
+        path = "experiments/experiment_1"
+    elif(param_x == "load_ratio"):
+        path = "experiments/experiment_2"
+    elif(param_x == "shards_per_node"):
+        path = "experiments/experiment_3"
+    
     for group in imbalance_lvl['algorithm'].unique():
         if(param_x == "cloud_load"):
             x = imbalance_lvl[imbalance_lvl['algorithm'] == group]['cload_load_lvl'].tolist()
@@ -231,13 +238,22 @@ def generate_imbalance_plots(imbalance_lvl, param_x, xLabel, plotTitle):
                  imbalance_lvl[imbalance_lvl['algorithm'] == group]['imbalance_percentage'].tolist(),
                  label=group,
                  linewidth=2)
+    path = path + "/" + plotTitle + "_" + getCurrentDateTime()
     plt.legend(loc="upper right")
     plt.xlabel(xLabel)
     plt.ylabel("Percentage value of imbalance")
-    plt.savefig(plotTitle + ".png")
+    plt.savefig(path + ".png")
 
 def generate_delays_plots(delays_df, param_x, xLabel, plotTitle):
     plt.clf()
+
+    if(param_x == "cloud_load"):
+        path = "experiments/experiment_1"
+    elif(param_x == "load_ratio"):
+        path = "experiments/experiment_2"
+    elif(param_x == "shards_per_node"):
+        path = "experiments/experiment_3"
+
     for group in delays_df['algorithm'].unique():
         if(param_x == "cloud_load"):
             x = delays_df[delays_df['algorithm'] == group]['cload_load_lvl'].tolist()
@@ -249,10 +265,11 @@ def generate_delays_plots(delays_df, param_x, xLabel, plotTitle):
                  delays_df[delays_df['algorithm'] == group]['delay_percentage'].tolist(),
                  label=group,
                  linewidth=2)
+    path = path + "/" + plotTitle + "_" + getCurrentDateTime()
     plt.legend(loc="upper right")
     plt.xlabel(xLabel)
     plt.ylabel("Percentage value of total delay")
-    plt.savefig(plotTitle + ".png")
+    plt.savefig(path + ".png")
 
 
 def simulation(parallel_requests, period, nodes, algorithm):

--- a/experiment_executor.py
+++ b/experiment_executor.py
@@ -10,15 +10,16 @@ from simulator.shard_allocator import diff_list
 from simulator.shard_allocator import shard_allocator
 from simulator.simulator import simulator
 import math
+from datetime import datetime
 
 num_of_shards = 0
 
 
 def experiment_executor():
     clear_directory()
-    experiment = int(input("Which experiment?:"))
-    while experiment not in [1, 2, 3]:
-        experiment = int(input("Which experiment? (Enter number from 1 to 3):"))
+    experiment = str(input("Which experiment?:"))
+    while experiment not in ['1', '2', '3', 'all']:
+        experiment = str(input("Which experiment? (Enter number from 1 to 3):"))
 
     algorithms = str(input("Which allocation algorithm?:"))
     while algorithms not in ["random", "sequential", "SALP", "all"]:
@@ -42,12 +43,16 @@ def experiment_executor():
 
     requests, load_vectors = generate_load_vectors(num_of_shards, num_of_samples, period, shape, scale)
 
-    if(experiment == 1):
+    if(experiment == '1'):
         experiment_one(num_of_samples, period, num_of_nodes, algorithms, shape, scale, load_vectors)
-    elif(experiment == 2):
+    elif(experiment == '2'):
         experiment_two(num_of_samples, period, algorithms, num_of_nodes, parallel_requests)
-    elif(experiment == 3):
+    elif(experiment == '3'):
         experiment_three(algorithms, parallel_requests, period, num_of_samples, shape, scale, load_vectors)
+    elif(experiment == 'all'):
+        experiment_one(num_of_samples, period, num_of_nodes, algorithms, shape, scale, load_vectors)
+        experiment_three(algorithms, parallel_requests, period, num_of_samples, shape, scale, load_vectors)
+        experiment_two(num_of_samples, period, algorithms, num_of_nodes, parallel_requests)
     else:
         print("Wrong experiment!")
 
@@ -68,27 +73,30 @@ def experiment_one(num_of_samples, period, num_of_nodes, algorithms, shape, scal
     processing_time = sum(load_vectors_df.sum(axis = 1))
     periods_in_vector = load_vectors_df.shape[1]
 
-    
     min_parallel_requests = round(processing_time / (periods_in_vector * num_of_nodes * 0.9))
     max_parallel_requests = round(processing_time / (periods_in_vector * num_of_nodes * 0.1))
 
-    delays_df = pd.DataFrame(columns=['algorithm', 'nodes', 'num_of_parallel_requests', 'sum_of_delay', 'delay_percentage'])
-
-    imbalance_df = pd.DataFrame(columns=['algorithm', 'nodes', 'num_of_parallel_requests', 'sum_of_imbalance', 'imbalance_percentage'])
+    delays_df = pd.DataFrame(columns=['algorithm', 'nodes', 'cload_load_lvl', 'sum_of_delay', 'delay_percentage'])
+    imbalance_df = pd.DataFrame(columns=['algorithm', 'nodes', 'cload_load_lvl', 'sum_of_imbalance', 'imbalance_percentage'])
 
     for parallel_requests in range(min_parallel_requests, max_parallel_requests + 1, 1):
         for algorithm in algorithms:
+            cload_load_lvl = processing_time / (periods_in_vector * num_of_nodes * parallel_requests)
+
             nodes_detail_df = shard_allocation(num_of_nodes, algorithm)
             imbalance_df = imbalance_df.append(calculate_imbalance_level(algorithm, num_of_nodes, load_vectors, nodes_detail_df,
-                                             num_of_parallel_requests = parallel_requests), ignore_index=True)
+                                             cload_load_lvl = cload_load_lvl), ignore_index=True)
 
             requests_completed_df = simulation(parallel_requests, period, num_of_nodes, algorithm)
 
             delays_df = delays_df.append(calculate_delays(num_of_samples, period, algorithm, num_of_nodes, requests_completed_df,
-                                        num_of_parallel_requests = parallel_requests), ignore_index=True)
+                                        cload_load_lvl = cload_load_lvl), ignore_index=True)
     
-    generate_delays_plots(delays_df, "cloud_load", "Cloud load level", "delays_cload_load", processing_time, periods_in_vector, num_of_nodes)
-    generate_imbalance_plots(imbalance_df, "cloud_load", "Cloud load level", "imbalance_lvl_cload_load", processing_time, periods_in_vector, num_of_nodes)
+    delays_df.to_csv('./experiments/experiment_1/delays_' + getCurrentDateTime() + '.csv', index=False)
+    imbalance_df.to_csv('./experiments/experiment_1/imbalance_' + getCurrentDateTime() + '.csv', index = False)
+
+    generate_delays_plots(delays_df, "cloud_load", "Cloud load level", "delays_cload_load")
+    generate_imbalance_plots(imbalance_df, "cloud_load", "Cloud load level", "imbalance_lvl_cload_load")
 
 def experiment_two(num_of_samples, period, algorithms, nodes, parallel_requests):
     shape = 25.0
@@ -97,7 +105,6 @@ def experiment_two(num_of_samples, period, algorithms, nodes, parallel_requests)
     mean = shape * scale
 
     delays_df = pd.DataFrame(columns=['algorithm', 'nodes', 'load_ratio', 'sum_of_delay', 'delay_percentage'])
-
     imbalance_df = pd.DataFrame(columns=['algorithm', 'nodes', 'load_ratio', 'sum_of_imbalance', 'imbalance_percentage'])
 
     for alfa in np.arange(1.0, shape, 1.0):
@@ -119,6 +126,9 @@ def experiment_two(num_of_samples, period, algorithms, nodes, parallel_requests)
             delays_df = delays_df.append(calculate_delays(num_of_samples, period, algorithm, nodes, requests_completed_df,
                                         load_ratio = load_ratio), ignore_index=True)
 
+    delays_df.to_csv('./experiments/experiment_2/delays_' + getCurrentDateTime() + '.csv', index=False)
+    imbalance_df.to_csv('./experiments/experiment_2/imbalance_' + getCurrentDateTime() + '.csv', index = False)
+
     generate_delays_plots(delays_df, "load_ratio", "Load Ratio", "delays_load_ratio")
     generate_imbalance_plots(imbalance_df, "load_ratio", "Load Ratio", "imbalance_lvl_load_ratio")
     
@@ -129,23 +139,29 @@ def experiment_three(algorithms, parallel_requests, period, num_of_samples, shap
         min_num_of_nodes = 1
     max_num_of_nodes = round(num_of_shards / 10)
 
-    delays_df = pd.DataFrame(columns=['algorithm', 'nodes', 'sum_of_delay', 'delay_percentage'])
+    delays_df = pd.DataFrame(columns=['algorithm', 'nodes', 'sum_of_delay', 'delay_percentage', 'shards_per_node_ratio'])
 
-    imbalance_df = pd.DataFrame(columns=['algorithm', 'nodes', 'sum_of_imbalance', 'imbalance_percentage'])
+    imbalance_df = pd.DataFrame(columns=['algorithm', 'nodes', 'sum_of_imbalance', 'imbalance_percentage', 'shards_per_node_ratio'])
 
     for nodes in range(min_num_of_nodes, max_num_of_nodes + 1, 1):
         for algorithm in algorithms:
+            shards_per_node_ratio = 1 / nodes
             nodes_detail_df = shard_allocation(nodes, algorithm)
-            imbalance_df = imbalance_df.append(calculate_imbalance_level(algorithm, nodes, load_vectors, nodes_detail_df), ignore_index=True)
+            imbalance_df = imbalance_df.append(calculate_imbalance_level(algorithm, nodes, load_vectors, nodes_detail_df,
+                                                shards_per_node_ratio = shards_per_node_ratio),ignore_index=True)
 
             requests_completed_df = simulation(parallel_requests, period, nodes, algorithm)
 
-            delays_df = delays_df.append(calculate_delays(num_of_samples, period, algorithm, nodes, requests_completed_df), ignore_index=True)
+            delays_df = delays_df.append(calculate_delays(num_of_samples, period, algorithm, nodes, requests_completed_df,
+                                        shards_per_node_ratio = shards_per_node_ratio),ignore_index=True)
+
+    delays_df.to_csv('./experiments/experiment_3/delays_' + getCurrentDateTime() + '.csv', index=False)
+    imbalance_df.to_csv('./experiments/experiment_3/imbalance_' + getCurrentDateTime() + '.csv', index = False)
 
     generate_delays_plots(delays_df, "shards_per_node", "Shards per node ratio", "delays_shards_per_node")
     generate_imbalance_plots(imbalance_df, "shards_per_node", "Shards per node ratio", "imbalance_lvl_shards_per_node")
 
-def calculate_delays(num_of_samples, period, algorithm, nodes, requests_completed_df, num_of_parallel_requests = None, load_ratio = None):
+def calculate_delays(num_of_samples, period, algorithm, nodes, requests_completed_df, shards_per_node_ratio = None, cload_load_lvl = None, load_ratio = None):
     complete_processing_time = num_of_samples * period
 
     ignored_requests = requests_completed_df[requests_completed_df['timestamp'] >= complete_processing_time]
@@ -163,19 +179,20 @@ def calculate_delays(num_of_samples, period, algorithm, nodes, requests_complete
         total_delay = observed_requests['delay'].sum()
         percentage_delay = (total_delay / complete_processing_time) * 100.0
     
-    if (num_of_parallel_requests == None and load_ratio == None):
-        to_append = {'algorithm': algorithm, 'nodes': nodes, 'sum_of_delay': total_delay, 'delay_percentage': percentage_delay}
-    elif(num_of_parallel_requests != None and load_ratio == None):
-        to_append = {'algorithm': algorithm, 'nodes': nodes, 'num_of_parallel_requests' : num_of_parallel_requests, 'sum_of_delay': total_delay,
+    if (cload_load_lvl == None and load_ratio == None and shards_per_node_ratio != None):
+        to_append = {'algorithm': algorithm, 'nodes': nodes, 'sum_of_delay': total_delay, 'delay_percentage': percentage_delay,
+                    'shards_per_node_ratio' : shards_per_node_ratio}
+    elif(cload_load_lvl != None and load_ratio == None and shards_per_node_ratio == None):
+        to_append = {'algorithm': algorithm, 'nodes': nodes, 'cload_load_lvl' : cload_load_lvl, 'sum_of_delay': total_delay,
                  'delay_percentage': percentage_delay}
-    elif(num_of_parallel_requests == None and load_ratio != None):
+    elif(cload_load_lvl == None and load_ratio != None and shards_per_node_ratio == None):
         to_append = {'algorithm': algorithm, 'nodes': nodes, 'load_ratio' : load_ratio, 'sum_of_delay': total_delay,
                  'delay_percentage': percentage_delay}
     else:
         to_append = None
     return to_append
 
-def calculate_imbalance_level(algorithm, nodes, load_vectors, nodes_detail_df, num_of_parallel_requests = None, load_ratio = None):
+def calculate_imbalance_level(algorithm, nodes, load_vectors, nodes_detail_df, shards_per_node_ratio = None, cload_load_lvl = None, load_ratio = None):
     load_vectors_df = pd.DataFrame(load_vectors)
     WTS = load_vectors_df.sum(axis=0)
     NWTS = WTS / nodes
@@ -187,13 +204,13 @@ def calculate_imbalance_level(algorithm, nodes, load_vectors, nodes_detail_df, n
             calculate_manhattan_vector_module(diff_list(row['load_vector'], NWTS)))
     imb_lvl = (sum_imbalance / NWTS_module) * 100.0
 
-    if(num_of_parallel_requests == None and load_ratio == None):
+    if(cload_load_lvl == None and load_ratio == None and shards_per_node_ratio != None):
         to_append = {'algorithm': algorithm, 'nodes': nodes, 'sum_of_imbalance': sum_imbalance,
+            'imbalance_percentage': imb_lvl, 'shards_per_node_ratio' : shards_per_node_ratio}
+    elif(cload_load_lvl != None and load_ratio == None and shards_per_node_ratio == None):
+        to_append = {'algorithm': algorithm, 'nodes': nodes, 'cload_load_lvl' : cload_load_lvl, 'sum_of_imbalance': sum_imbalance,
             'imbalance_percentage': imb_lvl}
-    elif(num_of_parallel_requests != None and load_ratio == None):
-        to_append = {'algorithm': algorithm, 'nodes': nodes, 'num_of_parallel_requests' : num_of_parallel_requests, 'sum_of_imbalance': sum_imbalance,
-            'imbalance_percentage': imb_lvl}
-    elif(num_of_parallel_requests == None and load_ratio != None):
+    elif(cload_load_lvl == None and load_ratio != None and shards_per_node_ratio == None):
         to_append = {'algorithm': algorithm, 'nodes': nodes, 'load_ratio' : load_ratio, 'sum_of_imbalance': sum_imbalance,
             'imbalance_percentage': imb_lvl}
     else:
@@ -201,15 +218,15 @@ def calculate_imbalance_level(algorithm, nodes, load_vectors, nodes_detail_df, n
 
     return to_append
 
-def generate_imbalance_plots(imbalance_lvl, param_x, xLabel, plotTitle, processing_time = None, periods_in_vector = None, num_of_nodes = None):
+def generate_imbalance_plots(imbalance_lvl, param_x, xLabel, plotTitle):
     plt.clf()
     for group in imbalance_lvl['algorithm'].unique():
         if(param_x == "cloud_load"):
-            x = imbalance_lvl[imbalance_lvl['algorithm'] == group]['num_of_parallel_requests'].map(lambda x: processing_time/(periods_in_vector * num_of_nodes * x)).tolist()
+            x = imbalance_lvl[imbalance_lvl['algorithm'] == group]['cload_load_lvl'].tolist()
         elif(param_x == "load_ratio"):
             x = imbalance_lvl[imbalance_lvl['algorithm'] == group]['load_ratio'].tolist()
         elif(param_x == "shards_per_node"):
-            x = imbalance_lvl[imbalance_lvl['algorithm'] == group]['nodes'].map(lambda x: 1 / x).tolist()
+            x = imbalance_lvl[imbalance_lvl['algorithm'] == group]['shards_per_node_ratio'].tolist()
         plt.plot(x,
                  imbalance_lvl[imbalance_lvl['algorithm'] == group]['imbalance_percentage'].tolist(),
                  label=group,
@@ -219,15 +236,15 @@ def generate_imbalance_plots(imbalance_lvl, param_x, xLabel, plotTitle, processi
     plt.ylabel("Percentage value of imbalance")
     plt.savefig(plotTitle + ".png")
 
-def generate_delays_plots(delays_df, param_x, xLabel, plotTitle, processing_time = None, periods_in_vector = None, num_of_nodes = None):
+def generate_delays_plots(delays_df, param_x, xLabel, plotTitle):
     plt.clf()
     for group in delays_df['algorithm'].unique():
         if(param_x == "cloud_load"):
-            x = delays_df[delays_df['algorithm'] == group]['num_of_parallel_requests'].map(lambda x: processing_time/(periods_in_vector * num_of_nodes * x)).tolist()
+            x = delays_df[delays_df['algorithm'] == group]['cload_load_lvl'].tolist()
         elif(param_x == "load_ratio"):
             x = delays_df[delays_df['algorithm'] == group]['load_ratio'].tolist()
         elif(param_x == "shards_per_node"):
-            x = delays_df[delays_df['algorithm'] == group]['nodes'].map(lambda x: 1 / x).tolist()
+            x = delays_df[delays_df['algorithm'] == group]['shards_per_node_ratio'].tolist()
         plt.plot(x,
                  delays_df[delays_df['algorithm'] == group]['delay_percentage'].tolist(),
                  label=group,
@@ -283,6 +300,13 @@ def clear_directory():
         os.system("rm -f ./experiments/load_vectors.csv")
         os.system("rm -f ./generator/load_vectors.csv")
 
+
+def getCurrentDateTime():
+    currentDateTime = datetime.now()
+
+    return str(currentDateTime.year) + '-' + str(currentDateTime.month) + '-' + \
+           str(currentDateTime.day) + '_' + str(currentDateTime.hour) +  '-' + \
+           str(currentDateTime.minute)
 
 if __name__ == "__main__":
     experiment_executor()

--- a/experiment_executor.py
+++ b/experiment_executor.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 
 import matplotlib.pyplot as plt
 import pandas as pd
@@ -16,7 +17,6 @@ num_of_shards = 0
 
 
 def experiment_executor():
-    clear_directory()
     experiment = str(input("Which experiment?:"))
     while experiment not in ['1', '2', '3', 'all']:
         experiment = str(input("Which experiment? (Enter number from 1 to 3):"))
@@ -294,12 +294,27 @@ def save_load_vector(load_vector):
 
 def clear_directory():
     try:
-        os.remove("experiments/load_vectors.csv")
-        os.remove("generator/load_vectors.csv")
+        if(os.path.exists("generator/load_vectors.csv") == True):
+            os.unlink("generator/load_vectors.csv")
+        if(os.path.exists("experiments/load_vectors.csv") == True ):
+            os.unlink("experiments/load_vectors.csv")
     except OSError:
-        os.system("rm -f ./experiments/load_vectors.csv")
-        os.system("rm -f ./generator/load_vectors.csv")
+        if(os.path.exists("./generator/load_vectors.csv") == True):
+            os.system("rm -f ./generator/load_vectors.csv")
+        if(os.path.exists("./experiments/load_vectors.csv") == True):
+            os.system("rm -f ./experiments/load_vectors.csv")
 
+
+def reset_directory():
+    if(os.path.exists("experiments") == True):
+        shutil.rmtree("experiments")
+    os.mkdir("experiments")
+    os.mkdir("experiments/experiment_1")
+    os.mkdir("experiments/experiment_2")
+    os.mkdir("experiments/experiment_3")
+    os.mkdir("experiments/SALP")
+    os.mkdir("experiments/random")
+    os.mkdir("experiments/sequential")
 
 def getCurrentDateTime():
     currentDateTime = datetime.now()
@@ -309,4 +324,5 @@ def getCurrentDateTime():
            str(currentDateTime.minute)
 
 if __name__ == "__main__":
+    reset_directory()
     experiment_executor()

--- a/experiment_executor.py
+++ b/experiment_executor.py
@@ -92,8 +92,8 @@ def experiment_one(num_of_samples, period, num_of_nodes, algorithms, shape, scal
             delays_df = delays_df.append(calculate_delays(num_of_samples, period, algorithm, num_of_nodes, requests_completed_df,
                                         cload_load_lvl = cload_load_lvl), ignore_index=True)
     
-    delays_df.to_csv('./experiments/experiment_1/delays_' + getCurrentDateTime() + '.csv', index=False)
-    imbalance_df.to_csv('./experiments/experiment_1/imbalance_' + getCurrentDateTime() + '.csv', index = False)
+    delays_df.to_csv('./results/experiment_1/delays_' + getCurrentDateTime() + '.csv', index=False)
+    imbalance_df.to_csv('./results/experiment_1/imbalance_' + getCurrentDateTime() + '.csv', index = False)
 
     generate_delays_plots(delays_df, "cloud_load", "Cloud load level", "delays_cload_load")
     generate_imbalance_plots(imbalance_df, "cloud_load", "Cloud load level", "imbalance_lvl_cload_load")
@@ -126,8 +126,8 @@ def experiment_two(num_of_samples, period, algorithms, nodes, parallel_requests)
             delays_df = delays_df.append(calculate_delays(num_of_samples, period, algorithm, nodes, requests_completed_df,
                                         load_ratio = load_ratio), ignore_index=True)
 
-    delays_df.to_csv('./experiments/experiment_2/delays_' + getCurrentDateTime() + '.csv', index=False)
-    imbalance_df.to_csv('./experiments/experiment_2/imbalance_' + getCurrentDateTime() + '.csv', index = False)
+    delays_df.to_csv('./results/experiment_2/delays_' + getCurrentDateTime() + '.csv', index=False)
+    imbalance_df.to_csv('./results/experiment_2/imbalance_' + getCurrentDateTime() + '.csv', index = False)
 
     generate_delays_plots(delays_df, "load_ratio", "Load Ratio", "delays_load_ratio")
     generate_imbalance_plots(imbalance_df, "load_ratio", "Load Ratio", "imbalance_lvl_load_ratio")
@@ -155,8 +155,8 @@ def experiment_three(algorithms, parallel_requests, period, num_of_samples, shap
             delays_df = delays_df.append(calculate_delays(num_of_samples, period, algorithm, nodes, requests_completed_df,
                                         shards_per_node_ratio = shards_per_node_ratio),ignore_index=True)
 
-    delays_df.to_csv('./experiments/experiment_3/delays_' + getCurrentDateTime() + '.csv', index=False)
-    imbalance_df.to_csv('./experiments/experiment_3/imbalance_' + getCurrentDateTime() + '.csv', index = False)
+    delays_df.to_csv('./results/experiment_3/delays_' + getCurrentDateTime() + '.csv', index=False)
+    imbalance_df.to_csv('./results/experiment_3/imbalance_' + getCurrentDateTime() + '.csv', index = False)
 
     generate_delays_plots(delays_df, "shards_per_node", "Shards per node ratio", "delays_shards_per_node")
     generate_imbalance_plots(imbalance_df, "shards_per_node", "Shards per node ratio", "imbalance_lvl_shards_per_node")
@@ -221,11 +221,11 @@ def calculate_imbalance_level(algorithm, nodes, load_vectors, nodes_detail_df, s
 def generate_imbalance_plots(imbalance_lvl, param_x, xLabel, plotTitle):
     plt.clf()
     if(param_x == "cloud_load"):
-        path = "experiments/experiment_1"
+        path = "results/experiment_1"
     elif(param_x == "load_ratio"):
-        path = "experiments/experiment_2"
+        path = "results/experiment_2"
     elif(param_x == "shards_per_node"):
-        path = "experiments/experiment_3"
+        path = "results/experiment_3"
     
     for group in imbalance_lvl['algorithm'].unique():
         if(param_x == "cloud_load"):
@@ -248,11 +248,11 @@ def generate_delays_plots(delays_df, param_x, xLabel, plotTitle):
     plt.clf()
 
     if(param_x == "cloud_load"):
-        path = "experiments/experiment_1"
+        path = "results/experiment_1"
     elif(param_x == "load_ratio"):
-        path = "experiments/experiment_2"
+        path = "results/experiment_2"
     elif(param_x == "shards_per_node"):
-        path = "experiments/experiment_3"
+        path = "results/experiment_3"
 
     for group in delays_df['algorithm'].unique():
         if(param_x == "cloud_load"):
@@ -326,9 +326,6 @@ def reset_directory():
     if(os.path.exists("experiments") == True):
         shutil.rmtree("experiments")
     os.mkdir("experiments")
-    os.mkdir("experiments/experiment_1")
-    os.mkdir("experiments/experiment_2")
-    os.mkdir("experiments/experiment_3")
     os.mkdir("experiments/SALP")
     os.mkdir("experiments/random")
     os.mkdir("experiments/sequential")


### PR DESCRIPTION
**PLEASE FIRST READ THE FOLLOWS COMMENT!!!**

Changes:
 - added queue of experiments. From now, it is possible to prepare all of experiments with just one call (which experiment? all)
- saving result of experiments in folders (experiment_1, experiment_2, experiment_3); the .csv file name is 'imbalance_'/'delays_' + number of experiment (1/2/3) + currentTime
- added function, which return current time (YYYY-MM-DD_hh-mm) as string -> it is needed for save results
- moved the calculation of ratio's from plots function to experiments funcion -> from now we do not need to map values in dataframes - ratio's are calculated in experiments function - it enables us the possibility of save ratio in result .csv file

-if we choose all experiments, first will be executed experiment 1 and 3 (because then we can compare the results of experiments on the same load vectors -> in experiment 2 new load vectors are generated)